### PR TITLE
Regen bug fix

### DIFF
--- a/backend/internal/game/combat.go
+++ b/backend/internal/game/combat.go
@@ -15,14 +15,14 @@ const (
 )
 
 // ApplyDamage subtracts health from the target and handles death side-effects.
-func (gm *GameMechanics) ApplyDamage(target *Player, damage int, attacker *Player, cause KillCause, now time.Time) bool {
+func (gm *GameMechanics) ApplyDamage(target *Player, damage float32, attacker *Player, cause KillCause, now time.Time) bool {
 	if target == nil || target.State != StateAlive || damage <= 0 {
 		return false
 	}
 
 	if damage == 0 {
 		log.Printf("Warning: Attempted to apply zero damage to Player %d", target.ID)
-		damage = 1 // Ensure at least 1 damage is applied
+		damage = 1.0 // Ensure at least 1 damage is applied
 	}
 
 	target.Health -= damage
@@ -35,7 +35,7 @@ func (gm *GameMechanics) ApplyDamage(target *Player, damage int, attacker *Playe
 }
 
 func (gm *GameMechanics) handlePlayerDeath(victim *Player, killer *Player, cause KillCause, now time.Time) {
-	victim.Health = 0
+	victim.Health = 0.0
 	victim.State = StateDead
 
 	// Track death information

--- a/backend/internal/game/combat.go
+++ b/backend/internal/game/combat.go
@@ -15,14 +15,14 @@ const (
 )
 
 // ApplyDamage subtracts health from the target and handles death side-effects.
-func (gm *GameMechanics) ApplyDamage(target *Player, damage float32, attacker *Player, cause KillCause, now time.Time) bool {
+func (gm *GameMechanics) ApplyDamage(target *Player, damage float64, attacker *Player, cause KillCause, now time.Time) bool {
 	if target == nil || target.State != StateAlive || damage <= 0 {
 		return false
 	}
 
 	if damage == 0 {
 		log.Printf("Warning: Attempted to apply zero damage to Player %d", target.ID)
-		damage = 1.0 // Ensure at least 1 damage is applied
+		damage = 1.0 // Ensure at least 1.0 damage is applied
 	}
 
 	target.Health -= damage

--- a/backend/internal/game/constants.go
+++ b/backend/internal/game/constants.go
@@ -40,7 +40,7 @@ const (
 
 // Combat constants
 const (
-	BaseCollisionDamage = 5   // Base damage dealt per collision
+	BaseCollisionDamage = 5.0   // Base damage dealt per collision
 	CollisionCooldown   = 0.2 // Seconds between collision damage ticks
 )
 

--- a/backend/internal/game/mechanics.go
+++ b/backend/internal/game/mechanics.go
@@ -83,11 +83,11 @@ func (gm *GameMechanics) handlePlayerCollision(player1, player2 *Player) {
 
 	// Frontal ram logic
 	if gm.isFrontalRam(player1, player2) && player1.ShipConfig.FrontUpgrade != nil && player1.ShipConfig.FrontUpgrade.Name == "Ram" {
-		ramDamage := 15 // Base ram damage, can be made configurable/stat-based
+		ramDamage := float32(15.0) // Base ram damage, can be made configurable/stat-based
 		gm.ApplyDamage(player2, ramDamage, player1, KillCauseRam, now)
 	}
 	if gm.isFrontalRam(player2, player1) && player2.ShipConfig.FrontUpgrade != nil && player2.ShipConfig.FrontUpgrade.Name == "Ram" {
-		ramDamage := 1
+		ramDamage := float32(1.0)
 		gm.ApplyDamage(player1, ramDamage, player2, KillCauseRam, now)
 	}
 }
@@ -173,7 +173,7 @@ func (gm *GameMechanics) applyCollisionDamage(player1, player2 *Player, now time
 	// Check if enough time has passed since last collision damage for player1
 	if now.Sub(player1.LastCollisionDamage) >= cooldown {
 		// Calculate damage from player1 to player2
-		damageToPlayer2 := BaseCollisionDamage + int(player1.Modifiers.BodyDamageBonus)
+		damageToPlayer2 := float32(BaseCollisionDamage + player1.Modifiers.BodyDamageBonus)
 		gm.ApplyDamage(player2, damageToPlayer2, player1, KillCauseCollision, now)
 
 		player1.LastCollisionDamage = now
@@ -182,7 +182,7 @@ func (gm *GameMechanics) applyCollisionDamage(player1, player2 *Player, now time
 	// Check if enough time has passed since last collision damage for player2
 	if now.Sub(player2.LastCollisionDamage) >= cooldown {
 		// Calculate damage from player2 to player1
-		damageToPlayer1 := BaseCollisionDamage + int(player2.Modifiers.BodyDamageBonus)
+		damageToPlayer1 := float32(BaseCollisionDamage + player2.Modifiers.BodyDamageBonus)
 		gm.ApplyDamage(player1, damageToPlayer1, player2, KillCauseCollision, now)
 
 		player2.LastCollisionDamage = now

--- a/backend/internal/game/mechanics.go
+++ b/backend/internal/game/mechanics.go
@@ -83,11 +83,11 @@ func (gm *GameMechanics) handlePlayerCollision(player1, player2 *Player) {
 
 	// Frontal ram logic
 	if gm.isFrontalRam(player1, player2) && player1.ShipConfig.FrontUpgrade != nil && player1.ShipConfig.FrontUpgrade.Name == "Ram" {
-		ramDamage := float32(15.0) // Base ram damage, can be made configurable/stat-based
+		ramDamage := 15.0 // Base ram damage, can be made configurable/stat-based
 		gm.ApplyDamage(player2, ramDamage, player1, KillCauseRam, now)
 	}
 	if gm.isFrontalRam(player2, player1) && player2.ShipConfig.FrontUpgrade != nil && player2.ShipConfig.FrontUpgrade.Name == "Ram" {
-		ramDamage := float32(1.0)
+		ramDamage := 1.0
 		gm.ApplyDamage(player1, ramDamage, player2, KillCauseRam, now)
 	}
 }
@@ -173,7 +173,7 @@ func (gm *GameMechanics) applyCollisionDamage(player1, player2 *Player, now time
 	// Check if enough time has passed since last collision damage for player1
 	if now.Sub(player1.LastCollisionDamage) >= cooldown {
 		// Calculate damage from player1 to player2
-		damageToPlayer2 := float32(BaseCollisionDamage + player1.Modifiers.BodyDamageBonus)
+		damageToPlayer2 := BaseCollisionDamage + player1.Modifiers.BodyDamageBonus
 		gm.ApplyDamage(player2, damageToPlayer2, player1, KillCauseCollision, now)
 
 		player1.LastCollisionDamage = now
@@ -182,7 +182,7 @@ func (gm *GameMechanics) applyCollisionDamage(player1, player2 *Player, now time
 	// Check if enough time has passed since last collision damage for player2
 	if now.Sub(player2.LastCollisionDamage) >= cooldown {
 		// Calculate damage from player2 to player1
-		damageToPlayer1 := float32(BaseCollisionDamage + player2.Modifiers.BodyDamageBonus)
+		damageToPlayer1 := BaseCollisionDamage + player2.Modifiers.BodyDamageBonus
 		gm.ApplyDamage(player1, damageToPlayer1, player2, KillCauseCollision, now)
 
 		player2.LastCollisionDamage = now

--- a/backend/internal/game/player.go
+++ b/backend/internal/game/player.go
@@ -52,8 +52,8 @@ func (player *Player) respawn() {
 	player.Level = 1
 	player.AvailableUpgrades = 0
 	player.Score = respawnScore
-	player.Health = 100
-	player.MaxHealth = 100
+	player.Health = 100.0
+	player.MaxHealth = 100.0
 	player.State = StateAlive
 	player.LastCollisionDamage = now
 
@@ -331,7 +331,7 @@ func (player *Player) updateModifiers() {
 	}
 
 	healthLevel := player.Upgrades[StatUpgradeHullStrength].Level
-	player.MaxHealth = 100 + (healthLevel * HealthIncrease)
+	player.MaxHealth = 100.0 + float32(healthLevel * HealthIncrease)
 
 	hullLevel := player.Upgrades[StatUpgradeHullStrength].Level
 	moveLevel := player.Upgrades[StatUpgradeMoveSpeed].Level
@@ -341,7 +341,7 @@ func (player *Player) updateModifiers() {
 	player.Modifiers.MoveSpeedMultiplier += moduleSpeedModifier
 
 	repairLevel := player.Upgrades[StatUpgradeAutoRepairs].Level
-	player.Modifiers.HealthRegenPerSec = float64(repairLevel) * 0.6
+	player.Modifiers.HealthRegenPerSec = 1.0 + (float64(repairLevel) * 0.6)
 
 	rangeLevel := player.Upgrades[StatUpgradeCannonRange].Level
 	player.Modifiers.BulletSpeedMultiplier = 1.0 + (float64(rangeLevel) * 0.05)

--- a/backend/internal/game/player.go
+++ b/backend/internal/game/player.go
@@ -331,7 +331,7 @@ func (player *Player) updateModifiers() {
 	}
 
 	healthLevel := player.Upgrades[StatUpgradeHullStrength].Level
-	player.MaxHealth = 100.0 + float32(healthLevel * HealthIncrease)
+	player.MaxHealth = 100.0 + float64(healthLevel * HealthIncrease)
 
 	hullLevel := player.Upgrades[StatUpgradeHullStrength].Level
 	moveLevel := player.Upgrades[StatUpgradeMoveSpeed].Level

--- a/backend/internal/game/types.go
+++ b/backend/internal/game/types.go
@@ -84,7 +84,7 @@ type Position struct {
 
 // DebugInfo contains calculated debug values for client display
 type DebugInfo struct {
-	Health            int     `msgpack:"health"`
+	Health            float32 `msgpack:"health"`
 	MoveSpeedModifier float64 `msgpack:"moveSpeedModifier"`
 	TurnSpeedModifier float64 `msgpack:"turnSpeedModifier"`
 	RegenRate         float64 `msgpack:"regenRate"`
@@ -109,8 +109,8 @@ type Player struct {
 	Name        string    `msgpack:"name"`
 	Color       string    `msgpack:"color"`
 	IsBot       bool      `msgpack:"isBot"`
-	Health      int       `msgpack:"health"`
-	MaxHealth   int       `msgpack:"maxHealth"`
+	Health      float32   `msgpack:"health"`
+	MaxHealth   float32   `msgpack:"maxHealth"`
 	RespawnTime time.Time `msgpack:"-"` // When the player can respawn (used only for bots)
 
 	Client *Client `msgpack:"-"` // Back-reference to owning client (not serialized)
@@ -179,7 +179,7 @@ type Bullet struct {
 	OwnerID   uint32    `msgpack:"-"`
 	CreatedAt time.Time `msgpack:"-"` // Not serialized
 	Radius    float64   `msgpack:"radius"`
-	Damage    int       `msgpack:"-"`
+	Damage    float32   `msgpack:"-"`
 }
 
 // Snapshot represents the current game state sent to clients
@@ -213,8 +213,8 @@ type PlayerDelta struct {
 	State             *int                     `msgpack:"state,omitempty"`             // Alive/dead state
 	Name              *string                  `msgpack:"name,omitempty"`              // Changes rarely
 	Color             *string                  `msgpack:"color,omitempty"`             // Changes rarely
-	Health            *int                     `msgpack:"health,omitempty"`            // Changes frequently
-	MaxHealth         *int                     `msgpack:"maxHealth,omitempty"`         // Changes with upgrades
+	Health            *float32                  `msgpack:"health,omitempty"`            // Changes frequently
+	MaxHealth         *float32                  `msgpack:"maxHealth,omitempty"`         // Changes with upgrades
 	Level             *int                     `msgpack:"level,omitempty"`             // Changes occasionally
 	Experience        *int                     `msgpack:"experience,omitempty"`        // Changes frequently
 	AvailableUpgrades *int                     `msgpack:"availableUpgrades,omitempty"` // Changes occasionally
@@ -372,8 +372,8 @@ func NewPlayer(id uint32) *Player {
 		X:                   WorldWidth / 2,
 		Y:                   WorldHeight / 2,
 		State:               StateAlive,
-		Health:              100,
-		MaxHealth:           100,
+		Health:              100.0,
+		MaxHealth:           100.0,
 		Modifiers:           mods,
 		Color:               generateRandomColor(),
 		Name:                generateRandomName(),

--- a/backend/internal/game/types.go
+++ b/backend/internal/game/types.go
@@ -84,7 +84,7 @@ type Position struct {
 
 // DebugInfo contains calculated debug values for client display
 type DebugInfo struct {
-	Health            float32 `msgpack:"health"`
+	Health            float64 `msgpack:"health"`
 	MoveSpeedModifier float64 `msgpack:"moveSpeedModifier"`
 	TurnSpeedModifier float64 `msgpack:"turnSpeedModifier"`
 	RegenRate         float64 `msgpack:"regenRate"`
@@ -109,8 +109,8 @@ type Player struct {
 	Name        string    `msgpack:"name"`
 	Color       string    `msgpack:"color"`
 	IsBot       bool      `msgpack:"isBot"`
-	Health      float32   `msgpack:"health"`
-	MaxHealth   float32   `msgpack:"maxHealth"`
+	Health      float64   `msgpack:"health"`
+	MaxHealth   float64   `msgpack:"maxHealth"`
 	RespawnTime time.Time `msgpack:"-"` // When the player can respawn (used only for bots)
 
 	Client *Client `msgpack:"-"` // Back-reference to owning client (not serialized)
@@ -179,7 +179,7 @@ type Bullet struct {
 	OwnerID   uint32    `msgpack:"-"`
 	CreatedAt time.Time `msgpack:"-"` // Not serialized
 	Radius    float64   `msgpack:"radius"`
-	Damage    float32   `msgpack:"-"`
+	Damage    float64   `msgpack:"-"`
 }
 
 // Snapshot represents the current game state sent to clients
@@ -213,8 +213,8 @@ type PlayerDelta struct {
 	State             *int                     `msgpack:"state,omitempty"`             // Alive/dead state
 	Name              *string                  `msgpack:"name,omitempty"`              // Changes rarely
 	Color             *string                  `msgpack:"color,omitempty"`             // Changes rarely
-	Health            *float32                  `msgpack:"health,omitempty"`            // Changes frequently
-	MaxHealth         *float32                  `msgpack:"maxHealth,omitempty"`         // Changes with upgrades
+	Health            *float64                  `msgpack:"health,omitempty"`            // Changes frequently
+	MaxHealth         *float64                  `msgpack:"maxHealth,omitempty"`         // Changes with upgrades
 	Level             *int                     `msgpack:"level,omitempty"`             // Changes occasionally
 	Experience        *int                     `msgpack:"experience,omitempty"`        // Changes frequently
 	AvailableUpgrades *int                     `msgpack:"availableUpgrades,omitempty"` // Changes occasionally

--- a/backend/internal/game/weapons.go
+++ b/backend/internal/game/weapons.go
@@ -94,7 +94,7 @@ func (c *Cannon) ForceFire(world *World, player *Player, targetAngle float64, no
 			OwnerID:   player.ID,
 			CreatedAt: now,
 			Radius:    bulletSize,
-			Damage:    float32(finalDamage),
+			Damage:    finalDamage,
 		}
 
 		bullets = append(bullets, bullet)

--- a/backend/internal/game/weapons.go
+++ b/backend/internal/game/weapons.go
@@ -94,7 +94,7 @@ func (c *Cannon) ForceFire(world *World, player *Player, targetAngle float64, no
 			OwnerID:   player.ID,
 			CreatedAt: now,
 			Radius:    bulletSize,
-			Damage:    int(finalDamage),
+			Damage:    float32(finalDamage),
 		}
 
 		bullets = append(bullets, bullet)

--- a/backend/internal/game/world.go
+++ b/backend/internal/game/world.go
@@ -375,8 +375,8 @@ func (w *World) updatePlayer(player *Player, input *InputMsg) {
 
 	// Handle health regeneration from auto repairs upgrade
 	// Regenerate health based on time elapsed
-	elapsedSeconds := float32(1.0 / float64(TickRate))
-	healthToRegen := elapsedSeconds * float32(player.Modifiers.HealthRegenPerSec)
+	elapsedSeconds := 1.0 / float64(TickRate)
+	healthToRegen := elapsedSeconds * player.Modifiers.HealthRegenPerSec
 	if healthToRegen > 0 && player.Health < player.MaxHealth {
 		player.Health += healthToRegen
 		if player.Health > player.MaxHealth {
@@ -566,9 +566,9 @@ func (w *World) updateBullets() {
 			// Only do expensive collision check if close enough (player size + some margin)
 			if distSq < 10000 && w.checkBulletPlayerCollision(bullet, player) { // 100^2 = 10000
 				// Apply damage through mechanics system (handles death + rewards)
-				damage := bullet.Damage * float32(attacker.Modifiers.BulletDamageMultiplier)
+				damage := bullet.Damage * attacker.Modifiers.BulletDamageMultiplier
 				if damage == 0 {
-					damage = float32(BulletDamage)
+					damage = float64(BulletDamage)
 					log.Printf("Bullet damage calculated as 0 for player %d, defaulting to %d", attacker.ID, BulletDamage)
 				}
 				w.mechanics.ApplyDamage(player, damage, attacker, KillCauseBullet, now)

--- a/backend/internal/game/world.go
+++ b/backend/internal/game/world.go
@@ -375,8 +375,8 @@ func (w *World) updatePlayer(player *Player, input *InputMsg) {
 
 	// Handle health regeneration from auto repairs upgrade
 	// Regenerate health based on time elapsed
-	elapsedSeconds := float64(1 / TickRate)
-	healthToRegen := int(elapsedSeconds * player.Modifiers.HealthRegenPerSec)
+	elapsedSeconds := float32(1.0 / float64(TickRate))
+	healthToRegen := elapsedSeconds * float32(player.Modifiers.HealthRegenPerSec)
 	if healthToRegen > 0 && player.Health < player.MaxHealth {
 		player.Health += healthToRegen
 		if player.Health > player.MaxHealth {
@@ -566,9 +566,9 @@ func (w *World) updateBullets() {
 			// Only do expensive collision check if close enough (player size + some margin)
 			if distSq < 10000 && w.checkBulletPlayerCollision(bullet, player) { // 100^2 = 10000
 				// Apply damage through mechanics system (handles death + rewards)
-				damage := bullet.Damage * int(attacker.Modifiers.BulletDamageMultiplier)
+				damage := bullet.Damage * float32(attacker.Modifiers.BulletDamageMultiplier)
 				if damage == 0 {
-					damage = BulletDamage
+					damage = float32(BulletDamage)
 					log.Printf("Bullet damage calculated as 0 for player %d, defaulting to %d", attacker.ID, BulletDamage)
 				}
 				w.mechanics.ApplyDamage(player, damage, attacker, KillCauseBullet, now)


### PR DESCRIPTION
issue 1: level 0 regen means level 0 health regenerated bc there was no 1.0 floor (fixed by adding 1.0 ro regen per sec)
issue 2: level 1+ regen was getting cast to an int but elapsed time was often a decimal and regen per sec itself is a decimal so that effectively makes health regen 0 unless regen is huge (fixed by converting all health related fields to a float)
issue 3: damage was not a float, so subtracting damage from health lead to type errors (fixed by converting damage and related fields to a float)
potential future issues: now that health/damage is a float, frontend has to make sure that it is handling that right (i am pretty sure it is fine tho)